### PR TITLE
デプロイの際のエラーを修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,3 +402,5 @@ RUBY VERSION
 
 BUNDLED WITH
    2.3.7
+
+bundle lock --add-platform x86_64-linux


### PR DESCRIPTION
bundle lock --add-platform x86_64-linux
を Gemfilelockに記述した